### PR TITLE
feat: gradle 9.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,6 @@ repositories {
 	mavenLocal()
 }
 
-sourceCompatibility = 17
-targetCompatibility = 17
-
 spotless {
 	groovyGradle {
 		target '*.gradle', '**/*.gradle'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Increase to gradle 9.0.0 to get rid of issues from [CVE-2025-4949](https://nvd.nist.gov/vuln/detail/CVE-2025-4949)