### PR TITLE
Support for subprojects

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 #
-#Mon Aug 11 20:38:52 CEST 2025
+#Wed Sep 10 08:02:38 CEST 2025
 adjustExistingGradlePluginPlugins=true
 description=Find dependencies that can be updated and task that updates them.
 group=se.bjurr.gradle
 publishGradlePluginToGradlePortal=false
 repoType=GRADLE
 tags=dependencymanagement
-version=1.1.1
+version=1.1.2

--- a/src/main/groovy/se.bjurr.gradle.update-versions.gradle
+++ b/src/main/groovy/se.bjurr.gradle.update-versions.gradle
@@ -52,15 +52,7 @@ def isNonStable(v) {
 }
 
 def getBuildGradleFile() {
-	File gradleFile = new File("$rootDir/build.gradle")
-	File gradleKtsFile = new File("$rootDir/build.gradle.kts")
-	if (gradleFile.exists()) {
-		return gradleFile
-	} else if (gradleKtsFile.exists()) {
-		return gradleKtsFile
-	} else {
-		throw new FileNotFoundException("Could not find build.gradle or build.gradle.kts in $rootDir")
-	}
+	return buildscript.sourceFile
 }
 
 task showUpdateableDependencies(type: com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask) {

--- a/src/main/groovy/se.bjurr.gradle.update-versions.gradle
+++ b/src/main/groovy/se.bjurr.gradle.update-versions.gradle
@@ -52,7 +52,12 @@ def isNonStable(v) {
 }
 
 def getBuildGradleFile() {
-	return buildscript.sourceFile
+	File gradleFile = buildscript.sourceFile
+	if (gradleFile == null) {
+		throw new FileNotFoundException("Could not get gradle build source file.")
+	} else {
+		return gradleFile
+	}
 }
 
 task showUpdateableDependencies(type: com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask) {


### PR DESCRIPTION
This PR handles build scripts in subprojects. At the same time it simplifies how the build file is resolved, it does not need to have two IF branches for kotlin and gradle build file formats. It just takes the actually processed build script file using gradle API.